### PR TITLE
comment out unused acl cloudflare

### DIFF
--- a/wordpress-example.vcl
+++ b/wordpress-example.vcl
@@ -12,10 +12,10 @@ include "lib/bigfiles.vcl";        # Varnish 3.0.3+
 #include "lib/bigfiles_pipe.vcl";  # Varnish 3.0.2
 include "lib/static.vcl";
 
-acl cloudflare {
+#acl cloudflare {
 	# set this ip to your Railgun IP (if applicable)
 	# "1.2.3.4";
-}
+#}
 
 acl purge {
 	"localhost";


### PR DESCRIPTION
If the acl cloudflare is not used it should be commented out.

root@my-wp:/etc/varnish# service varnish restart
[ ok ] Stopping HTTP accelerator: varnishd.
[FAIL] Starting HTTP accelerator: varnishd failed!

Message from VCC-compiler:
Unused acl cloudflare, defined:
('input' Line 15 Pos 5)
acl cloudflare {
----##########--

Running VCC-compiler failed, exit 1

VCL compilation failed
